### PR TITLE
Make binding a configurable option and the Spotify URL point to the actual URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Press tmux `prefix + s` (for example, `C-a s`) and you will see a nice menu:
 * Close menu      (q) - close menu
 ```
 
+## Configuring the binding
+
+The binding may be configured via your `.tmux.conf` as:
+
+```
+set -g @spotifybinding 'S'
+```
+
 ## Other plugins
 * [tmux-network-bandwidth](https://github.com/xamut/tmux-network-bandwidth)
 * [tmux-weather](https://github.com/xamut/tmux-weather)

--- a/scripts/spotify.sh
+++ b/scripts/spotify.sh
@@ -89,7 +89,7 @@ show_menu() {
         "-#[nodim]Artist: $artist"    "" "" \
         "-#[nodim]Album: $album"      "" "" \
         "" \
-        "Copy URL"         c "run -b 'printf \"%s\" $id | pbcopy'" \
+        "Copy URL"         c "run -b 'printf \"%s\" $id | sed \"s/spotify:track:/https:\/\/open.spotify.com\/track\//\" | pbcopy'" \
         "Open Spotify"     o "run -b 'source \"$CURRENT_DIR/spotify.sh\" && open_spotify'" \
         "Play/Pause"       p "run -b 'source \"$CURRENT_DIR/spotify.sh\" && toggle_play_pause'" \
         "Previous"         b "run -b 'source \"$CURRENT_DIR/spotify.sh\" && previous_track'" \

--- a/scripts/spotify.sh
+++ b/scripts/spotify.sh
@@ -72,7 +72,7 @@ show_menu() {
         "-#[nodim]Episode: $track_name" "" "" \
         "-#[nodim]Podcast: $album"      "" "" \
         "" \
-        "Copy URL"         c "run -b 'printf \"%s\" $id | pbcopy'" \
+        "Copy URL"         c "run -b 'printf \"%s\" $id | sed \"s/spotify:track:/https:\/\/open.spotify.com\/track\//\" | pbcopy'" \
         "Open Spotify"     o "run -b 'source \"$CURRENT_DIR/spotify.sh\" && open_spotify'" \
         "Play/Pause"       p "run -b 'source \"$CURRENT_DIR/spotify.sh\" && toggle_play_pause'" \
         "Previous"         b "run -b 'source \"$CURRENT_DIR/spotify.sh\" && previous_track'" \

--- a/tmux-spotify.tmux
+++ b/tmux-spotify.tmux
@@ -3,8 +3,27 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PATH="/usr/local/bin:$PATH:/usr/sbin"
 
+default_binding_key="s"
+binding_option="@spotifybinding"
+
+get_tmux_option() {
+	local option="$1"
+	local default_value="$2"
+	local option_value=$(tmux show-option -gqv "$option")
+	if [ -z "$option_value" ]; then
+		echo "$default_value"
+	else
+		echo "$option_value"
+	fi
+}
+
 main() {
-  $(tmux bind-key -T prefix S run -b "source $CURRENT_DIR/scripts/spotify.sh && show_menu")
+	local key_bindings=$(get_tmux_option "$binding_option" "$default_binding_key")
+	local key
+
+	for key in $key_bindings; do
+    tmux bind-key -T prefix "$key" run -b "source $CURRENT_DIR/scripts/spotify.sh && show_menu"
+  done
 }
 
 main

--- a/tmux-spotify.tmux
+++ b/tmux-spotify.tmux
@@ -4,7 +4,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PATH="/usr/local/bin:$PATH:/usr/sbin"
 
 main() {
-  $(tmux bind-key -T prefix s run -b "source $CURRENT_DIR/scripts/spotify.sh && show_menu")
+  $(tmux bind-key -T prefix S run -b "source $CURRENT_DIR/scripts/spotify.sh && show_menu")
 }
 
 main


### PR DESCRIPTION
Hi!

The PR is fairly small, so it might be quicker to skip through the code, but it basically:

- Allows users to configure the binding through an option such as: `set -g @spotifybinding 'S'` in their `.tmux.conf`.
-  Has the `Copy URL` command actually return the song's URL instead of its ID.

I hope it helps!